### PR TITLE
Include <cstdint> in sds_string.h

### DIFF
--- a/include/sds/sds_string.h
+++ b/include/sds/sds_string.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace sds
 {


### PR DESCRIPTION
To define uint32_t and uint16_t